### PR TITLE
Stop following symlinks 216

### DIFF
--- a/gitless/cli/helpers.py
+++ b/gitless/cli/helpers.py
@@ -121,7 +121,10 @@ class PathProcessor(argparse.Action):
     def process_paths():
       for path in paths:
         path = os.path.abspath(path)
-        if self.recursive and os.path.isdir(path):
+        # Treat symlinks as normal files, even if the link points to a
+        # directory. The directory could be outside of the repo, then things
+        # get weird... This is standard git behavior.
+        if self.recursive and os.path.isdir(path) and not os.path.islink(path):
           for curr_dir, dirs, fps in os.walk(path, topdown=True):
             if curr_dir.startswith(normalized_repo_path):
               dirs[:] = []

--- a/gitless/tests/test_core.py
+++ b/gitless/tests/test_core.py
@@ -188,11 +188,11 @@ class TestFile(TestCore):
     utils_lib.write_file(IGNORED_FP_WITH_SPACE)
     utils_lib.write_file(GITTEST_FP)
 
-    # Testing with symlinks!
+    # Testing with symlinks! The symlink calls will be no ops on Windows
     utils_lib.write_file(SYMLINK_TARGET_FP, contents=SYMLINK_TARGET_FP_CONTENTS)
-    os.symlink(REPO_DIR, SYMLINK_GIT)
+    utils_lib.symlink(REPO_DIR, SYMLINK_GIT)
     os.mkdir(SYMLINK_DIR)
-    os.symlink(SYMLINK_TARGET, SYMLINK_FP)
+    utils_lib.symlink(SYMLINK_TARGET, SYMLINK_FP)
 
     self.curr_b = self.repo.current_branch
 
@@ -823,20 +823,22 @@ class TestFilePathProcessor(TestFile):
 
   @assert_no_side_effects(SYMLINK_TARGET_FP)
   def test_path_processor_track_symlink(self):
-      argv = ['track', SYMLINK_FP]
-      args = self.parser.parse_args(argv)
-      files = [fp for fp in args.files]
+    argv = ['track', SYMLINK_FP]
+    args = self.parser.parse_args(argv)
+    files = [fp for fp in args.files]
 
+    if os.path.exists(SYMLINK_FP):
       self.assertEqual(len(files), 1)
       self.assertTrue(SYMLINK_FP in files)
       self.assertFalse(SYMLINK_TARGET_FP in files)
 
   @assert_no_side_effects(SYMLINK_TARGET_FP)
   def test_path_processor_track_symlink_dir(self):
-      argv = ['track', SYMLINK_DIR]
-      args = self.parser.parse_args(argv)
-      files = [fp for fp in args.files]
+    argv = ['track', SYMLINK_DIR]
+    args = self.parser.parse_args(argv)
+    files = [fp for fp in args.files]
 
+    if os.path.exists(SYMLINK_FP):
       self.assertEqual(len(files), 1)
       self.assertTrue(SYMLINK_FP in files)
       self.assertFalse(SYMLINK_TARGET_FP in files)

--- a/gitless/tests/test_core.py
+++ b/gitless/tests/test_core.py
@@ -43,6 +43,12 @@ REPO_DIR = '.git'
 REPO_FP = os.path.join(REPO_DIR, 'HEAD')
 GITTEST_DIR = '.gittest'
 GITTEST_FP = os.path.join(GITTEST_DIR, 'fp')
+SYMLINK_TARGET = 'symtarget'
+SYMLINK_TARGET_FP_CONTENTS = 'symf1\n'
+SYMLINK_TARGET_FP = os.path.join(SYMLINK_TARGET, 'symf1')
+SYMLINK_DIR = 'symdir'
+SYMLINK_FP = os.path.join(SYMLINK_DIR, 'sym')
+SYMLINK_GIT = 'gitsym'
 UNTRACKED_DIR_FP = os.path.join(DIR, 'f1')
 UNTRACKED_DIR_FP_WITH_SPACE = os.path.join(DIR, 'f1 space')
 TRACKED_DIR_FP = os.path.join(DIR, 'f2')
@@ -57,12 +63,16 @@ ALL_FPS_IN_WD = [
     IGNORED_FP, IGNORED_FP_WITH_SPACE, UNTRACKED_DIR_FP,
     UNTRACKED_DIR_FP_WITH_SPACE, TRACKED_DIR_FP, TRACKED_DIR_FP_WITH_SPACE,
     UNTRACKED_DIR_DIR_FP, UNTRACKED_DIR_DIR_FP_WITH_SPACE, TRACKED_DIR_DIR_FP,
-    TRACKED_DIR_DIR_FP_WITH_SPACE, GITIGNORE_FP, GITTEST_FP]
+    TRACKED_DIR_DIR_FP_WITH_SPACE, GITIGNORE_FP, GITTEST_FP, SYMLINK_TARGET_FP,
+    SYMLINK_FP, SYMLINK_GIT]
+# the symbolic link is both a file and directory. The OS typically treats it
+# like a directory but we want to treat it as a file for tracking purposes.
 ALL_DIR_FPS_IN_WD = [
     TRACKED_DIR_FP, TRACKED_DIR_FP_WITH_SPACE, UNTRACKED_DIR_FP,
     UNTRACKED_DIR_FP_WITH_SPACE, TRACKED_DIR_DIR_FP,
     TRACKED_DIR_DIR_FP_WITH_SPACE, UNTRACKED_DIR_DIR_FP,
-    UNTRACKED_DIR_DIR_FP_WITH_SPACE, GITTEST_DIR]
+    UNTRACKED_DIR_DIR_FP_WITH_SPACE, GITTEST_DIR, SYMLINK_TARGET, SYMLINK_DIR,
+    SYMLINK_FP, SYMLINK_GIT]
 BRANCH = 'b1'
 REMOTE_BRANCH = 'rb'
 FP_IN_CONFLICT = 'f_conflict'
@@ -177,6 +187,12 @@ class TestFile(TestCore):
     utils_lib.write_file(IGNORED_FP)
     utils_lib.write_file(IGNORED_FP_WITH_SPACE)
     utils_lib.write_file(GITTEST_FP)
+
+    # Testing with symlinks!
+    utils_lib.write_file(SYMLINK_TARGET_FP, contents=SYMLINK_TARGET_FP_CONTENTS)
+    os.symlink(REPO_DIR, SYMLINK_GIT)
+    os.mkdir(SYMLINK_DIR)
+    os.symlink(SYMLINK_TARGET, SYMLINK_FP)
 
     self.curr_b = self.repo.current_branch
 
@@ -795,6 +811,35 @@ class TestFilePathProcessor(TestFile):
 
     self.assertEqual(len(files), 1)
     self.assertTrue(GITTEST_FP in files)
+
+  @assert_no_side_effects(GITTEST_FP)
+  def test_path_processor_track_gittest_fp(self):
+    argv = ['track', GITTEST_FP]
+    args = self.parser.parse_args(argv)
+    files = [fp for fp in args.files]
+
+    self.assertEqual(len(files), 1)
+    self.assertTrue(GITTEST_FP in files)
+
+  @assert_no_side_effects(SYMLINK_TARGET_FP)
+  def test_path_processor_track_symlink(self):
+      argv = ['track', SYMLINK_FP]
+      args = self.parser.parse_args(argv)
+      files = [fp for fp in args.files]
+
+      self.assertEqual(len(files), 1)
+      self.assertTrue(SYMLINK_FP in files)
+      self.assertFalse(SYMLINK_TARGET_FP in files)
+
+  @assert_no_side_effects(SYMLINK_TARGET_FP)
+  def test_path_processor_track_symlink_dir(self):
+      argv = ['track', SYMLINK_DIR]
+      args = self.parser.parse_args(argv)
+      files = [fp for fp in args.files]
+
+      self.assertEqual(len(files), 1)
+      self.assertTrue(SYMLINK_FP in files)
+      self.assertFalse(SYMLINK_TARGET_FP in files)
 
 
 # Unit tests for branch related operations

--- a/gitless/tests/utils.py
+++ b/gitless/tests/utils.py
@@ -82,9 +82,9 @@ def rmtree(path):
   logging.debug('Removed dir {0}'.format(path))
 
 
-def symlink(src, dst, target_is_directory=False, dir_fd=None):
+def symlink(src, dst):
   try:
-    os.symlink(src, dst, target_is_directory, dir_fd=dir_fd)
+    os.symlink(src, dst)
   except (AttributeError, NotImplementedError, OSError):
     # Swallow the exceptions, because Windows is very weird about creating
     # symlinks. Python 2 does not have a symlink method on in the os module,

--- a/gitless/tests/utils.py
+++ b/gitless/tests/utils.py
@@ -85,7 +85,7 @@ def rmtree(path):
 def symlink(src, dst, target_is_directory=False, dir_fd=None):
   try:
     os.symlink(src, dst, target_is_directory, dir_fd=dir_fd)
-  except AttributeError, NotImplementedError, OSError:
+  except (AttributeError, NotImplementedError, OSError):
     # Swallow the exceptions, because Windows is very weird about creating
     # symlinks. Python 2 does not have a symlink method on in the os module,
     # AttributeError will handle that. Python 3 does have a symlink method in

--- a/gitless/tests/utils.py
+++ b/gitless/tests/utils.py
@@ -82,6 +82,16 @@ def rmtree(path):
   logging.debug('Removed dir {0}'.format(path))
 
 
+def symlink(src, dst, target_is_directory=False, *, dir_fd=None):
+  try:
+    os.symlink(src, dst, target_is_directory, dir_fd=dir_fd)
+  except OSError:
+    # Swallow the OSError, because Windows is very weird about creating
+    # symlinks. Technically, python supports this if it is run with the right
+    # permissions. In that case, this will just work.
+    pass
+
+
 def write_file(fp, contents=''):
   _x_file('w', fp, contents=contents)
 

--- a/gitless/tests/utils.py
+++ b/gitless/tests/utils.py
@@ -85,10 +85,16 @@ def rmtree(path):
 def symlink(src, dst, target_is_directory=False, dir_fd=None):
   try:
     os.symlink(src, dst, target_is_directory, dir_fd=dir_fd)
-  except OSError:
-    # Swallow the OSError, because Windows is very weird about creating
-    # symlinks. Technically, python supports this if it is run with the right
-    # permissions. In that case, this will just work.
+  except AttributeError, NotImplementedError, OSError:
+    # Swallow the exceptions, because Windows is very weird about creating
+    # symlinks. Python 2 does not have a symlink method on in the os module,
+    # AttributeError will handle that. Python 3 does have a symlink method in
+    # the os module, however, it has some quirks. NotImplementedError handles
+    # the case where the Windows version is prior to Vista. OSError handles the
+    # case where python doesn't have permissions to create a symlink on
+    # windows. In all cases, it's not necessary to test this, so skip it.
+    # See: https://docs.python.org/3.5/library/os.html#os.symlink and
+    # https://docs.python.org/2.7/library/os.html#os.symlink for full details.
     pass
 
 

--- a/gitless/tests/utils.py
+++ b/gitless/tests/utils.py
@@ -82,7 +82,7 @@ def rmtree(path):
   logging.debug('Removed dir {0}'.format(path))
 
 
-def symlink(src, dst, target_is_directory=False, *, dir_fd=None):
+def symlink(src, dst, target_is_directory=False, dir_fd=None):
   try:
     os.symlink(src, dst, target_is_directory, dir_fd=dir_fd)
   except OSError:


### PR DESCRIPTION
Add a check for symlinks when we check if a path is a directory and treat the symlink as a normal
file. Gitless will NOT follow the symlinks, because it could pull in the .git/ directory, files
outside of the repository or, in the worst case, the entire filesystem. This follows the behavior of
git. Git will commit symlinks into the repository and recreate the links on filesystems that support
it when the file is downloaded.
