### PR TITLE
Update libgit2 to 0.99

### DIFF
--- a/.travis.sh
+++ b/.travis.sh
@@ -2,7 +2,7 @@
 
 cd ~
 
-git clone --depth=1 -b maint/v0.28 https://github.com/libgit2/libgit2.git
+git clone --depth=1 -b maint/v0.99 https://github.com/libgit2/libgit2.git
 cd libgit2/
 
 mkdir build && cd build

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 # make sure to update setup.py
 
-pygit2==0.28.2  # requires libgit2 0.28
+pygit2==1.1.1  # requires libgit2 0.99 or 1.0
 clint==0.5.1
 sh==1.12.14;sys_platform!='win32'
 pbs==0.110;sys_platform=='win32'

--- a/setup.py
+++ b/setup.py
@@ -68,7 +68,7 @@ setup(
     packages=['gitless', 'gitless.cli'],
     install_requires=[
       # make sure it matches requirements.txt
-      'pygit2==0.28.2', # requires libgit2 0.28
+      'pygit2==1.1.1', # requires libgit2 0.99 or 1.0
       'clint>=0.3.6',
       'sh>=1.11' if sys.platform != 'win32' else 'pbs>=0.11'
     ],

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -28,7 +28,7 @@ parts:
   libgit2:
     plugin: cmake
     # https://www.pygit2.org/install.html#version-numbers
-    source: https://github.com/libgit2/libgit2/archive/v0.28.2.tar.gz
+    source: https://github.com/libgit2/libgit2/archive/v0.99.0.tar.gz
     build-packages:
       - libssl-dev
 


### PR DESCRIPTION
This PR updates required version of `libgit2` to 0.99 and `pygit` to `1.1.1`.
I briefly had a look at [breaking changes in pygit2 changelog](https://github.com/libgit2/pygit2/blob/v1.1.1/CHANGELOG.rst), and it seems none of them affects the project.

These changes are required to get updated `libgit2` on Homebrew: https://github.com/Homebrew/homebrew-core/pull/51095