### PR TITLE
WIP: Add tab completion support with argcomplete

### DIFF
--- a/gitless/cli/gl.py
+++ b/gitless/cli/gl.py
@@ -9,6 +9,7 @@ from __future__ import unicode_literals
 
 import sys
 import argparse
+import argcomplete
 import traceback
 import pygit2
 
@@ -101,7 +102,7 @@ def main():
       gl_switch, gl_init, gl_history]
 
   parser = build_parser(sub_cmds, repo)
-
+  argcomplete.autocomplete(parser)
   if len(sys.argv) == 1:
     print_help(parser)
     return SUCCESS

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 # make sure to update setup.py
 
+argcomplete>=1.11.1
 pygit2==1.1.1  # requires libgit2 0.99 or 1.0
 clint==0.5.1
 sh==1.12.14;sys_platform!='win32'

--- a/setup.py
+++ b/setup.py
@@ -70,7 +70,8 @@ setup(
       # make sure it matches requirements.txt
       'pygit2==1.1.1', # requires libgit2 0.99 or 1.0
       'clint>=0.3.6',
-      'sh>=1.11' if sys.platform != 'win32' else 'pbs>=0.11'
+      'sh>=1.11' if sys.platform != 'win32' else 'pbs>=0.11',
+      'argcomplete>=1.11.1'
     ],
     license='MIT',
     classifiers=[


### PR DESCRIPTION
Fixes #226

Implemented using [argcomplete](https://kislyuk.github.io/argcomplete/)

Still needs automated install procedure. Screenshots of the tab completion in use, activated manually (in my personal fish shell, but argcomplete supports bash, zsh, fish and tzsh):

<img width="348" alt="Screenshot 2020-03-31 at 13 00 24" src="https://user-images.githubusercontent.com/13387304/78014049-08c61a80-7350-11ea-933e-69cb120a9f21.png">
<img width="393" alt="Screenshot 2020-03-31 at 13 00 19" src="https://user-images.githubusercontent.com/13387304/78014051-0a8fde00-7350-11ea-85e3-c96cfed6d693.png">

Which shells do we want to support automatic installation for? And what is the right place to hook a shell script completion installation? Offer it as an option (something like gl --install-completions) or as part of the pip / pyinstaller installation? https://stackoverflow.com/questions/58075926/python-argcomplete-and-pyinstaller Here's some info related to the technical implementation of automatically installing argcomplete completion in a pyinstaller packaged python application.

https://docs.pytest.org/en/latest/bash-completion.html pytest's documentation is a good example of documentation for manually enabling argcomplete completion.


