### PR TITLE
Add --move-ignored / -mi flag to "gl switch".

### DIFF
--- a/gitless/cli/gl_switch.py
+++ b/gitless/cli/gl_switch.py
@@ -21,6 +21,9 @@ def parser(subparsers, _):
       help='move uncomitted changes made in the current branch to the '
       'destination branch',
       action='store_true')
+  switch_parser.add_argument('-ni', '--no-stash-ignored',
+      help='do not stash ignored files, has no effect if --move-over is also set',
+      action='store_true')
   switch_parser.set_defaults(func=main)
 
 
@@ -33,6 +36,6 @@ def main(args, repo):
     pprint.err_exp('to create a new branch do gl branch -c {0}'.format(args.branch))
     return False
 
-  repo.switch_current_branch(b, move_over=args.move_over)
+  repo.switch_current_branch(b, move_over=args.move_over, no_stash_ignored=args.no_stash_ignored)
   pprint.ok('Switched to branch {0}'.format(args.branch))
   return True

--- a/gitless/cli/gl_switch.py
+++ b/gitless/cli/gl_switch.py
@@ -21,8 +21,9 @@ def parser(subparsers, _):
       help='move uncomitted changes made in the current branch to the '
       'destination branch',
       action='store_true')
-  switch_parser.add_argument('-ni', '--no-stash-ignored',
-      help='do not stash ignored files, has no effect if --move-over is also set',
+  switch_parser.add_argument('-mi', '--move-ignored',
+      help='move ignored files to the destination branch, '
+      'has no effect if --move-over is also set',
       action='store_true')
   switch_parser.set_defaults(func=main)
 
@@ -36,6 +37,6 @@ def main(args, repo):
     pprint.err_exp('to create a new branch do gl branch -c {0}'.format(args.branch))
     return False
 
-  repo.switch_current_branch(b, move_over=args.move_over, no_stash_ignored=args.no_stash_ignored)
+  repo.switch_current_branch(b, move_over=args.move_over, move_ignored=args.move_ignored)
   pprint.ok('Switched to branch {0}'.format(args.branch))
   return True

--- a/gitless/core.py
+++ b/gitless/core.py
@@ -256,13 +256,16 @@ class Repository(object):
     """
     return self.git_repo.listall_branches(pygit2.GIT_BRANCH_LOCAL)
 
-  def switch_current_branch(self, dst_b, move_over=False):
+  def switch_current_branch(self, dst_b, move_over=False, no_stash_ignored=False):
     """Switches to the given branch.
 
     Args:
       dst_b: the destination branch.
       move_over: if True, then uncommitted changes made in the current branch are
         moved to the destination branch (defaults to False).
+      no_stash_ignored: if move_over is False and no_stash_ignored is True, then
+        stash only non-ignored files. If both move_over and
+        no_stash_ignored are False, then stash all files, including ignored files.
     """
     if dst_b.is_current:
       raise ValueError(
@@ -346,7 +349,10 @@ class Repository(object):
 
       if not move_over:
         # Stash
-        git.stash.save('--all', '--', msg)
+        if no_stash_ignored:
+          git.stash.save('--include-untracked', '--', msg)
+        else:
+          git.stash.save('--all', '--', msg)
 
     def restore(b):
       s_id, msg = _stash(_stash_msg(b.branch_name))

--- a/gitless/core.py
+++ b/gitless/core.py
@@ -256,16 +256,15 @@ class Repository(object):
     """
     return self.git_repo.listall_branches(pygit2.GIT_BRANCH_LOCAL)
 
-  def switch_current_branch(self, dst_b, move_over=False, no_stash_ignored=False):
+  def switch_current_branch(self, dst_b, move_over=False, move_ignored=False):
     """Switches to the given branch.
 
     Args:
       dst_b: the destination branch.
       move_over: if True, then uncommitted changes made in the current branch are
         moved to the destination branch (defaults to False).
-      no_stash_ignored: if move_over is False and no_stash_ignored is True, then
-        stash only non-ignored files. If both move_over and
-        no_stash_ignored are False, then stash all files, including ignored files.
+      move_ignored: if True, and move_over is False, then ignored files are moved
+        to the destination branch, but uncommitted changes are not (defaults to False).
     """
     if dst_b.is_current:
       raise ValueError(
@@ -349,7 +348,7 @@ class Repository(object):
 
       if not move_over:
         # Stash
-        if no_stash_ignored:
+        if move_ignored:
           git.stash.save('--include-untracked', '--', msg)
         else:
           git.stash.save('--all', '--', msg)


### PR DESCRIPTION
Helps with #20, and potentially #134 by adding a `-mi` / `--move-ignored` flag to `gl switch`.

Tested on a repo with ~1GB of ignored files. `gl switch -mi <branch>` takes less than 10 seconds.