### PR TITLE
add AUR packages to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,16 @@ snap install --channel=beta gitless
 
 You can also use the `edge` channel to install the most recent build.
 
+### Installing via the Arch User Repository
+
+If you are using [Arch Linux](https://www.archlinux.org/) or any of
+its derivatives, you can use your favorite
+[AUR Helper](https://wiki.archlinux.org/index.php/AUR_helpers) and install:
+- [gitless](https://aur.archlinux.org/packages/gitless/) for the latest
+  released version
+- [gitless-git](https://aur.archlinux.org/packages/gitless-git/) to 
+  build the latest version straight from this repo
+
 Documentation
 -------------
 


### PR DESCRIPTION
Hey! I've just created the [gitless-git](https://aur.archlinux.org/packages/gitless-git/) package for Arch Linux users to quickly grab and though it would be cool to note in the README. I've also obviously mentioned the non-upstream gitless package in the AUR, that already existed.

Thanks for this project! 🥺